### PR TITLE
use port number passed into make and fix uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 output-*.gcode
+__pycache__

--- a/LightBurnAdapter.py
+++ b/LightBurnAdapter.py
@@ -21,7 +21,7 @@ streaming_args.add_argument('--serial', '-s', nargs=1, metavar='PORT',
     help='Open the serial port PORT. Most likely this should be one port of a virtual serial port pair like com0com or tty0tty.')
 
 target_device_args = parser.add_mutually_exclusive_group(required=True)
-target_device_args.add_argument('--ip', nargs=1,
+target_device_args.add_argument('--ip',
     help='IP address of the laser cutter device.')
 target_device_args.add_argument('--usb', action='store_const', dest='ip', const='201.234.3.1',
     help='Connect to laser cutter via USB (which is a network interface with IP 201.234.3.1).')
@@ -101,7 +101,7 @@ while True:
         answer = input(f'Upload {translated_file} to Lasercutter (y/n/d[elete])? ').lower()
     if answer == 'y':
         print('Okay, uploading. Press the blue button on the M1 to execute.')
-        m1.upload_gcode(file=translated_file)
+        m1.upload_gcode_file(filename=translated_file)
     elif answer == 'd' or answer == 'delete':
         print(f'Okay, deleting 2 files {filename(i)} and {translated_file}.')
         os.unlink(filename(i))

--- a/tcp_bridge/Makefile
+++ b/tcp_bridge/Makefile
@@ -1,4 +1,4 @@
-CFLAGS ?= -Wall -Werror -pedantic -DPORT=$(PORT)
+CFLAGS ?= -Wall -Werror -pedantic -D LISTEN_PORT=$(PORT)
 
 tcp_bridge: tcp_bridge.c
 	$(CC) $(CFLAGS) -o $@ $^

--- a/tcp_bridge/Makefile
+++ b/tcp_bridge/Makefile
@@ -9,3 +9,6 @@ tcp_bridge: tcp_bridge.c
 setcap: tcp_bridge
 	@echo "Please enter your sudo password to grant $< access to ports below 1024."
 	sudo setcap CAP_NET_BIND_SERVICE=+eip "$<"
+
+clean:
+	rm -f tcp_bridge

--- a/tcp_bridge/tcp_bridge.c
+++ b/tcp_bridge/tcp_bridge.c
@@ -14,7 +14,6 @@
 #define IP_TO_INT(A, B, C, D) (((A) & 0xFF) << 24 | ((B) & 0xFF) << 16 | ((C) & 0xFF) << 8 | ((D) & 0xFF))
 
 #define LISTEN_ADDRESS IP_TO_INT(127,0,0,1)
-#define LISTEN_PORT 23
 #define BUFFER_SIZE 1024
 #define MAX_CLIENTS 1
 


### PR DESCRIPTION
macOS does not have the `setcap` command so it seems it will be simpler on a Mac to use a port number like 8023 and change it in LightBurn device settings. But you're not actually using the port number passed into `make` – you're hardcoding it in the C source file.

<img width="834" alt="Screenshot 2022-08-07 at 17 52 17" src="https://user-images.githubusercontent.com/4921659/183302264-8ae4fb40-4d6a-4043-8a21-23f4996a91ae.png">